### PR TITLE
fix: 修复 visualize.py 中的 XSS 漏洞

### DIFF
--- a/.claude/skills/dashboard/scripts/visualize.py
+++ b/.claude/skills/dashboard/scripts/visualize.py
@@ -8,6 +8,7 @@ import re
 import os
 import webbrowser
 import tempfile
+from html import escape
 from pathlib import Path
 from datetime import datetime
 
@@ -90,11 +91,11 @@ def generate_html(data):
     for skill in data["skills"]:
         skills_html += f'''
         <div class="skill-card">
-            <div class="skill-name">{skill["name"]}</div>
-            <div class="skill-desc">{skill["desc"]}</div>
+            <div class="skill-name">{escape(skill["name"])}</div>
+            <div class="skill-desc">{escape(skill["desc"])}</div>
             <div class="skill-meta">
-                <span class="skill-version">{skill["version"]}</span>
-                <span class="skill-date">{skill["date"]}</span>
+                <span class="skill-version">{escape(skill["version"])}</span>
+                <span class="skill-date">{escape(skill["date"])}</span>
             </div>
         </div>
         '''
@@ -104,14 +105,14 @@ def generate_html(data):
     for dev in data["developing"]:
         developing_html += f'''
         <div class="dev-card">
-            <div class="dev-name">{dev["name"]}</div>
+            <div class="dev-name">{escape(dev["name"])}</div>
             <div class="progress-container">
                 <div class="progress-bar">
-                    <div class="progress-fill" style="width: {dev["progress"]}%"></div>
+                    <div class="progress-fill" style="width: {int(dev["progress"])}%"></div>
                 </div>
-                <span class="progress-text">{dev["progress"]}%</span>
+                <span class="progress-text">{int(dev["progress"])}%</span>
             </div>
-            <div class="dev-next">{dev["next"]}</div>
+            <div class="dev-next">{escape(dev["next"])}</div>
         </div>
         '''
 
@@ -121,8 +122,8 @@ def generate_html(data):
         priority_class = "high" if plan["priority"] == "高" else "mid" if plan["priority"] == "中" else "low"
         planned_html += f'''
         <div class="plan-item">
-            <span class="plan-name">{plan["name"]}</span>
-            <span class="priority {priority_class}">{plan["priority"]}</span>
+            <span class="plan-name">{escape(plan["name"])}</span>
+            <span class="priority {priority_class}">{escape(plan["priority"])}</span>
         </div>
         '''
 


### PR DESCRIPTION
## Summary

- 使用 `html.escape()` 转义所有用户输入，防止 XSS 攻击
- 对 `progress` 字段强制转换为 `int`，防止样式注入

## 修改内容

修复 `.claude/skills/dashboard/scripts/visualize.py` 中的以下位置：

| 区域 | 转义字段 |
|------|----------|
| 技能卡片 | `name`, `desc`, `version`, `date` |
| 开发中卡片 | `name`, `next` |
| 规划中列表 | `name`, `priority` |

## 测试方法

在 `DASHBOARD.md` 中添加恶意内容测试：

```markdown
| `<script>alert('xss')</script>` | 测试 | v1.0 | 2026-01-27 | 测试 |
```

运行 `/dashboard` 后，恶意代码应被转义为文本显示，而非执行。

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)