### PR TITLE
✨ feat(feishu): 飞书流式卡片 + CHANNEL_WEB 开关 + PS1 路径修复

### DIFF
--- a/.claude/skills/mycc/SKILL.md
+++ b/.claude/skills/mycc/SKILL.md
@@ -97,16 +97,28 @@ npx tsx .claude/skills/mycc/scripts/src/index.ts start
 sleep 5 && cat .claude/skills/mycc/current.json
 ```
 
+### 3.5 检查通道开关
+
+读取 `.env` 中的 `CHANNEL_WEB` 值（默认为 `true`）：
+```bash
+grep CHANNEL_WEB .env 2>/dev/null || echo "CHANNEL_WEB=true"
+```
+
 ### 4. 告知用户
 
-**连接信息**：
+**通道状态**（根据 `.env` 实际配置显示）：
+- Web 通道：`CHANNEL_WEB=false` 时已禁用，**不要展示 Web URL，不要打开浏览器**
+- 飞书通道：配置 `FEISHU_APP_ID` 等环境变量后自动启动
+
+**如果 Web 通道已启用（`CHANNEL_WEB` 不为 `false`）**，展示：
 - 连接码（routeToken）
 - 配对码（pairCode）
 - 访问 https://mycc.dev 输入配对
 
-**通道状态**：
-- Web 通道：默认启动
-- 飞书通道：配置环境变量后自动启动
+**如果 Web 通道已禁用（`CHANNEL_WEB=false`）**，只展示：
+- 飞书通道状态
+- tunnel URL（供飞书事件订阅用）
+- 不展示 mpUrl，不提及 mycc.dev
 
 ## 飞书模式配置
 

--- a/.claude/skills/mycc/scripts/package-lock.json
+++ b/.claude/skills/mycc/scripts/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "cc-miniprogram",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-miniprogram",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.63",
         "@larksuiteoapi/node-sdk": "^1.59.0",
         "chalk": "^4.1.2",
         "nanoid": "^5.0.0",
@@ -47,22 +47,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.42",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.42.tgz",
-      "integrity": "sha512-/CugP7AjP57Dqtl2sbsDtxdbpQoPKIhjyF5WrTViGu4NHQdM+UikrRs4MhZ2jeotiC5R7iK9ZUN9SiBgcZ8oLw==",
+      "version": "0.2.70",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.70.tgz",
+      "integrity": "sha512-ABaB37jWt7dZXfIDHebHv99jX9GIyqc0aSjcz9nxq79eauOpa+64Cah5hx/yzhsWz7m5GEtjbMIZCClTfnRRhg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-linuxmusl-arm64": "^0.33.5",
-        "@img/sharp-linuxmusl-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -568,9 +569,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -586,13 +587,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -608,13 +609,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -628,9 +629,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -644,9 +645,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -660,9 +661,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -676,9 +677,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +693,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -708,9 +709,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -724,9 +725,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -742,13 +743,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -764,13 +765,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -786,13 +787,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -808,13 +809,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -830,13 +831,32 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],

--- a/.claude/skills/mycc/scripts/src/channels/feishu-commands.ts
+++ b/.claude/skills/mycc/scripts/src/channels/feishu-commands.ts
@@ -7,6 +7,7 @@
 import type { CCAdapter } from "../adapters/interface.js";
 import type { ChannelManager } from "./manager.js";
 import type { DeviceConfig } from "../types.js";
+import type { FeishuStreamingSession } from "./feishu-streaming.js";
 
 export interface FeishuCommandsDeps {
   adapter: CCAdapter;
@@ -34,8 +35,11 @@ export class FeishuCommands {
 
   /**
    * 处理飞书收到的消息
+   * @param message - 消息文本
+   * @param images - 图片数组
+   * @param messageId - 原始消息 ID，用于回复和流式卡片
    */
-  async processMessage(message: string, images?: Array<{ data: string; mediaType: string }>): Promise<void> {
+  async processMessage(message: string, images?: Array<{ data: string; mediaType: string }>, messageId?: string): Promise<void> {
     console.log(`[CC] 收到飞书消息: ${message.substring(0, 50)}...${images ? ` [${images.length} 张图片]` : ""}`);
 
     const trimmedMessage = message.trim();
@@ -75,6 +79,28 @@ export class FeishuCommands {
 
     console.log(`[CC] 使用当前会话: ${this._currentSessionId}`);
 
+    // 尝试启动流式卡片（单卡片实时更新，替代逐条消息）
+    let streamingSession: FeishuStreamingSession | null = null;
+    const feishuChannel = this.deps.feishuChannel;
+
+    if (feishuChannel && messageId) {
+      try {
+        const cfg = feishuChannel.getConfig();
+        if (cfg.appId && cfg.appSecret && cfg.receiveUserId) {
+          const session = feishuChannel.createStreamingSession();
+          const idType = cfg.receiveIdType === "chat_id" ? "chat_id" : "open_id";
+          await session.start(cfg.receiveUserId, idType, messageId);
+          streamingSession = session;
+          console.log(`[CC] 流式卡片已启动`);
+        }
+      } catch (err) {
+        console.warn(`[CC] 流式卡片启动失败，降级为普通消息: ${err}`);
+        streamingSession = null;
+      }
+    }
+
+    let accumulatedText = "";
+
     try {
       for await (const data of this.deps.adapter.chat({
         message: trimmedMessage,
@@ -87,43 +113,73 @@ export class FeishuCommands {
             this._currentSessionId = data.session_id as string;
             console.log(`[CC] 会话已更新: ${this._currentSessionId}`);
           }
-          if (data.type === "text" && data.text) {
-            const text = String(data.text);
-            console.log(`[CC] 发送文本: ${text.substring(0, 30)}...`);
-            await this.sendToFeishu(text);
-          } else if (data.type === "assistant") {
-            const assistantEvent = data as any;
-            if (assistantEvent.message?.content) {
-              for (const block of assistantEvent.message.content) {
-                if (block.type === "text" && block.text) {
-                  const text = String(block.text);
-                  console.log(`[CC] 发送文本: ${text.substring(0, 30)}...`);
-                  await this.sendToFeishu(text);
-                } else if (block.type === "tool_use") {
-                  const name = block.name || "unknown";
-                  let toolCallText = `**使用工具: ${name}**`;
-                  if (block.input && Object.keys(block.input).length > 0) {
-                    const inputStr = JSON.stringify(block.input, null, 2);
-                    if (inputStr.length > 300) {
-                      toolCallText += `\n\`\`\`\n${inputStr.substring(0, 300)}...\n\`\`\``;
-                    } else {
-                      toolCallText += `\n\`\`\`\n${inputStr}\n\`\`\``;
-                    }
+
+          if (streamingSession) {
+            // 流式卡片模式：收集文本并实时更新
+            if (data.type === "text" && data.text) {
+              accumulatedText += String(data.text);
+              await streamingSession.update(accumulatedText);
+            } else if (data.type === "assistant") {
+              const content = (data as any).message?.content;
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (block.type === "text" && block.text) {
+                    accumulatedText += String(block.text);
                   }
-                  console.log(`[CC] 发送工具调用: ${name}`);
-                  await this.sendToFeishu(toolCallText);
+                }
+                await streamingSession.update(accumulatedText);
+              }
+            }
+          } else {
+            // 降级模式：逐条发送
+            if (data.type === "text" && data.text) {
+              const text = String(data.text);
+              console.log(`[CC] 发送文本: ${text.substring(0, 30)}...`);
+              await this.sendToFeishu(text);
+            } else if (data.type === "assistant") {
+              const assistantEvent = data as any;
+              if (assistantEvent.message?.content) {
+                for (const block of assistantEvent.message.content) {
+                  if (block.type === "text" && block.text) {
+                    const text = String(block.text);
+                    console.log(`[CC] 发送文本: ${text.substring(0, 30)}...`);
+                    await this.sendToFeishu(text);
+                  } else if (block.type === "tool_use") {
+                    const name = block.name || "unknown";
+                    let toolCallText = `**使用工具: ${name}**`;
+                    if (block.input && Object.keys(block.input).length > 0) {
+                      const inputStr = JSON.stringify(block.input, null, 2);
+                      toolCallText +=
+                        inputStr.length > 300
+                          ? `\n\`\`\`\n${inputStr.substring(0, 300)}...\n\`\`\``
+                          : `\n\`\`\`\n${inputStr}\n\`\`\``;
+                    }
+                    console.log(`[CC] 发送工具调用: ${name}`);
+                    await this.sendToFeishu(toolCallText);
+                  }
                 }
               }
             }
           }
         }
       }
+
+      // 关闭流式卡片
+      if (streamingSession) {
+        await streamingSession.close(accumulatedText || undefined);
+      }
     } catch (err) {
       console.error(`[CC] 处理飞书消息错误:`, err);
-      await this.sendToFeishu("处理消息时出错，请重试。");
+      if (streamingSession) {
+        await streamingSession
+          .close(accumulatedText || "处理消息时出错，请重试。")
+          .catch(() => {});
+      } else {
+        await this.sendToFeishu("处理消息时出错，请重试。");
+      }
     } finally {
-      if (this.deps.feishuChannel) {
-        await this.deps.feishuChannel.clearTypingIndicator();
+      if (feishuChannel) {
+        await feishuChannel.clearTypingIndicator();
       }
     }
   }

--- a/.claude/skills/mycc/scripts/src/channels/feishu-streaming.ts
+++ b/.claude/skills/mycc/scripts/src/channels/feishu-streaming.ts
@@ -1,0 +1,370 @@
+/**
+ * 飞书流式卡片 + 工具函数
+ *
+ * 集成自 clawdbot-feishu（MIT License）
+ * 来源: https://github.com/m1heng/clawdbot-feishu
+ *
+ * 主要功能：
+ * - FeishuStreamingSession: 流式卡片，AI 回复实时更新到单个卡片
+ * - buildMarkdownCard: 构建 schema 2.0 markdown 卡片（完整 markdown 支持）
+ * - normalizeFeishuMarkdownLinks: 规范化 URL，避免飞书截断
+ */
+
+// ==================== normalizeFeishuMarkdownLinks ====================
+
+const FENCED_CODE_BLOCK_RE = /(```[\s\S]*?```)/g;
+const INLINE_CODE_RE = /(`[^`\n]*`)/g;
+const URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+const TRAILING_PUNCT_RE = /[.,;!?\u3002\uff0c\uff1b\uff01\uff1f\u3001]/u;
+const AUTO_LINK_RE = /<\s*(https?:\/\/[^>\s]+)\s*>/g;
+
+function normalizeUrlForFeishu(url: string): string {
+  return url.replace(/_/g, "%5F").replace(/\(/g, "%28").replace(/\)/g, "%29");
+}
+
+function buildMarkdownLink(url: string): string {
+  const label = url.replace(/[\[\]]/g, "\\$&");
+  return `[${label}](${url})`;
+}
+
+function countParens(text: string): { open: number; close: number } {
+  let open = 0,
+    close = 0;
+  for (const c of text) {
+    if (c === "(") open++;
+    else if (c === ")") close++;
+  }
+  return { open, close };
+}
+
+function splitTrailingPunctuation(rawUrl: string): { url: string; trailing: string } {
+  let url = rawUrl,
+    trailing = "";
+  let { open, close } = countParens(rawUrl);
+  while (url.length > 0) {
+    const tail = url.slice(-1);
+    const closeParenOverflow = tail === ")" && close > open;
+    if (!TRAILING_PUNCT_RE.test(tail) && !closeParenOverflow) break;
+    if (tail === ")") close--;
+    trailing = tail + trailing;
+    url = url.slice(0, -1);
+  }
+  return { url, trailing };
+}
+
+function wrapBareUrls(text: string): string {
+  const converted = text.replace(AUTO_LINK_RE, (_full, rawUrl: string) => {
+    const { url, trailing } = splitTrailingPunctuation(rawUrl);
+    if (!url) return _full;
+    return `${buildMarkdownLink(normalizeUrlForFeishu(url))}${trailing}`;
+  });
+  return converted.replace(URL_RE, (raw, offset, input) => {
+    const { url, trailing } = splitTrailingPunctuation(raw);
+    if (!url) return raw;
+    const isMarkdownDestination = offset >= 2 && input.slice(offset - 2, offset) === "](";
+    const normalizedUrl = normalizeUrlForFeishu(url);
+    if (isMarkdownDestination) return `${normalizedUrl}${trailing}`;
+    return `${buildMarkdownLink(normalizedUrl)}${trailing}`;
+  });
+}
+
+function normalizeNonCodeSegments(text: string): string {
+  return text
+    .split(INLINE_CODE_RE)
+    .map((seg, idx) => (idx % 2 === 1 && seg.startsWith("`") ? seg : wrapBareUrls(seg)))
+    .join("");
+}
+
+/**
+ * 规范化飞书 markdown 中的 URL
+ * 将裸 URL 和自动链接转换为标准 markdown 链接格式，避免飞书截断
+ */
+export function normalizeFeishuMarkdownLinks(text: string): string {
+  if (!text || (!text.includes("http://") && !text.includes("https://"))) return text;
+  return text
+    .split(FENCED_CODE_BLOCK_RE)
+    .map((block, idx) =>
+      idx % 2 === 1 && block.startsWith("```") ? block : normalizeNonCodeSegments(block)
+    )
+    .join("");
+}
+
+// ==================== buildMarkdownCard ====================
+
+/**
+ * 构建飞书 schema 2.0 markdown 卡片
+ * 完整支持代码块、表格、链接、加粗等 markdown 语法
+ */
+export function buildMarkdownCard(text: string): Record<string, unknown> {
+  return {
+    schema: "2.0",
+    config: { wide_screen_mode: true },
+    body: {
+      elements: [{ tag: "markdown", content: text }],
+    },
+  };
+}
+
+// ==================== FeishuStreamingSession ====================
+
+const API_BASE = "https://open.feishu.cn/open-apis";
+
+type Credentials = { appId: string; appSecret: string };
+type CardState = { cardId: string; messageId: string; sequence: number; currentText: string };
+
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+async function getFeishuToken(creds: Credentials): Promise<string> {
+  const key = creds.appId;
+  const cached = tokenCache.get(key);
+  if (cached && cached.expiresAt > Date.now() + 60000) return cached.token;
+
+  const res = await fetch(`${API_BASE}/auth/v3/tenant_access_token/internal`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ app_id: creds.appId, app_secret: creds.appSecret }),
+  });
+  const data = (await res.json()) as {
+    code: number;
+    msg: string;
+    tenant_access_token?: string;
+    expire?: number;
+  };
+  if (data.code !== 0 || !data.tenant_access_token)
+    throw new Error(`Token error: ${data.msg}`);
+  tokenCache.set(key, {
+    token: data.tenant_access_token,
+    expiresAt: Date.now() + (data.expire ?? 7200) * 1000,
+  });
+  return data.tenant_access_token;
+}
+
+function truncateSummary(text: string, max = 50): string {
+  const clean = text.replace(/\n/g, " ").trim();
+  return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
+}
+
+function mergeStreamingText(
+  prev: string | undefined,
+  next: string | undefined
+): string {
+  const p = typeof prev === "string" ? prev : "";
+  const n = typeof next === "string" ? next : "";
+  if (!n) return p;
+  if (!p || n === p || n.includes(p)) return n;
+  if (p.includes(n)) return p;
+  return p + n;
+}
+
+/**
+ * 飞书流式卡片会话
+ *
+ * 用法：
+ * 1. session.start(receiveId, receiveIdType, replyToMessageId?)
+ * 2. session.update(text)  // 随文本增长调用
+ * 3. session.close(finalText?)
+ *
+ * 如果 CardKit API 不可用（权限不足等），会抛出错误，
+ * 调用方应降级到普通消息发送。
+ */
+export class FeishuStreamingSession {
+  private creds: Credentials;
+  private state: CardState | null = null;
+  private queue: Promise<void> = Promise.resolve();
+  private closed = false;
+  private lastUpdateTime = 0;
+  private pendingText: string | null = null;
+  private readonly updateThrottleMs = 100;
+  private log?: (msg: string) => void;
+
+  constructor(creds: Credentials, log?: (msg: string) => void) {
+    this.creds = creds;
+    this.log = log;
+  }
+
+  async start(
+    receiveId: string,
+    receiveIdType: "open_id" | "user_id" | "union_id" | "email" | "chat_id",
+    replyToMessageId?: string
+  ): Promise<void> {
+    if (this.state) return;
+
+    const token = await getFeishuToken(this.creds);
+
+    // 创建流式卡片（streaming_mode: true）
+    const cardJson = {
+      schema: "2.0",
+      config: {
+        streaming_mode: true,
+        summary: { content: "[生成中...]" },
+        streaming_config: {
+          print_frequency_ms: { default: 50 },
+          print_step: { default: 2 },
+        },
+      },
+      body: {
+        elements: [{ tag: "markdown", content: "思考中...", element_id: "content" }],
+      },
+    };
+
+    const createRes = await fetch(`${API_BASE}/cardkit/v1/cards`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ type: "card_json", data: JSON.stringify(cardJson) }),
+    });
+    const createData = (await createRes.json()) as {
+      code: number;
+      msg: string;
+      data?: { card_id: string };
+    };
+    if (createData.code !== 0 || !createData.data?.card_id) {
+      throw new Error(
+        `CardKit 创建卡片失败 (code ${createData.code}): ${createData.msg}`
+      );
+    }
+    const cardId = createData.data.card_id;
+
+    // 发送卡片（或回复消息）
+    const cardContent = JSON.stringify({ type: "card", data: { card_id: cardId } });
+    const sendUrl = replyToMessageId
+      ? `${API_BASE}/im/v1/messages/${replyToMessageId}/reply`
+      : `${API_BASE}/im/v1/messages?receive_id_type=${receiveIdType}`;
+    const sendBody = replyToMessageId
+      ? { msg_type: "interactive", content: cardContent }
+      : { receive_id: receiveId, msg_type: "interactive", content: cardContent };
+
+    const sendRes = await fetch(sendUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(sendBody),
+    });
+    const sendData = (await sendRes.json()) as {
+      code: number;
+      msg: string;
+      data?: { message_id: string };
+    };
+    if (sendData.code !== 0 || !sendData.data?.message_id) {
+      throw new Error(
+        `发送卡片失败 (code ${sendData.code}): ${sendData.msg}`
+      );
+    }
+
+    this.state = {
+      cardId,
+      messageId: sendData.data.message_id,
+      sequence: 1,
+      currentText: "",
+    };
+    this.log?.(`[Streaming] 已启动: cardId=${cardId}, messageId=${sendData.data.message_id}`);
+  }
+
+  async update(text: string): Promise<void> {
+    if (!this.state || this.closed) return;
+    const merged = mergeStreamingText(
+      this.pendingText ?? this.state.currentText,
+      text
+    );
+    if (!merged || merged === this.state.currentText) return;
+
+    const now = Date.now();
+    if (now - this.lastUpdateTime < this.updateThrottleMs) {
+      this.pendingText = merged;
+      return;
+    }
+    this.pendingText = null;
+    this.lastUpdateTime = now;
+
+    this.queue = this.queue.then(async () => {
+      if (!this.state || this.closed) return;
+      const mergedText = mergeStreamingText(this.state.currentText, merged);
+      if (!mergedText || mergedText === this.state.currentText) return;
+      this.state.currentText = mergedText;
+      this.state.sequence += 1;
+      await fetch(
+        `${API_BASE}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${await getFeishuToken(this.creds)}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            content: mergedText,
+            sequence: this.state.sequence,
+            uuid: `s_${this.state.cardId}_${this.state.sequence}`,
+          }),
+        }
+      ).catch((e) => this.log?.(`Update failed: ${String(e)}`));
+    });
+    await this.queue;
+  }
+
+  async close(finalText?: string): Promise<void> {
+    if (!this.state || this.closed) return;
+    this.closed = true;
+    await this.queue;
+
+    const pendingMerged = mergeStreamingText(
+      this.state.currentText,
+      this.pendingText ?? undefined
+    );
+    const text = finalText
+      ? mergeStreamingText(pendingMerged, finalText)
+      : pendingMerged;
+    const token = await getFeishuToken(this.creds);
+
+    // 最终文本更新
+    if (text && text !== this.state.currentText) {
+      this.state.sequence += 1;
+      await fetch(
+        `${API_BASE}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            content: text,
+            sequence: this.state.sequence,
+            uuid: `s_${this.state.cardId}_${this.state.sequence}`,
+          }),
+        }
+      ).catch(() => {});
+      this.state.currentText = text;
+    }
+
+    // 关闭流式模式
+    const summary = text ? truncateSummary(text) : "";
+    this.state.sequence += 1;
+    await fetch(`${API_BASE}/cardkit/v1/cards/${this.state.cardId}/settings`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        settings: JSON.stringify({
+          config: {
+            streaming_mode: false,
+            summary: { content: summary },
+          },
+        }),
+        sequence: this.state.sequence,
+        uuid: `c_${this.state.cardId}_${this.state.sequence}`,
+      }),
+    }).catch((e) => this.log?.(`Close failed: ${String(e)}`));
+
+    this.log?.(`[Streaming] 已完成: cardId=${this.state.cardId}`);
+  }
+
+  isActive(): boolean {
+    return this.state !== null && !this.closed;
+  }
+}

--- a/.claude/skills/mycc/scripts/src/channels/feishu.ts
+++ b/.claude/skills/mycc/scripts/src/channels/feishu.ts
@@ -9,6 +9,11 @@
 import type { MessageChannel } from "./interface.js";
 import type { SSEEvent } from "../adapters/interface.js";
 import Lark from "@larksuiteoapi/node-sdk";
+import {
+  FeishuStreamingSession,
+  buildMarkdownCard,
+  normalizeFeishuMarkdownLinks,
+} from "./feishu-streaming.js";
 
 /**
  * 飞书通道配置
@@ -663,17 +668,9 @@ export class FeishuChannel implements MessageChannel {
 
       const receiveIdType = this.config.receiveIdType || "open_id";
 
-      // 检查文本中是否包含表格
-      const tableData = this.parseMarkdownTable(text);
-
-      if (tableData) {
-        // 使用交互卡片 + 表格组件
-        const cardContent = this.buildTableCard(tableData.beforeTable, tableData.headers, tableData.rows, tableData.afterTable);
-        return await this.sendInteractiveCard(userId, cardContent);
-      }
-
-      // 没有表格，使用普通 Markdown 消息
-      return await this.sendMarkdownMessage(userId, text);
+      // 使用 schema 2.0 markdown 卡片（支持代码块、表格、链接等完整 markdown）
+      const normalizedText = normalizeFeishuMarkdownLinks(text);
+      return await this.sendMarkdownCardMessage(userId, normalizedText);
     } catch (error) {
       console.error("[FeishuChannel] ✗ Send error:", error);
       return false;
@@ -718,42 +715,45 @@ export class FeishuChannel implements MessageChannel {
   }
 
   /**
-   * 发送 Markdown 消息
+   * 发送 schema 2.0 markdown 卡片消息
+   * 完整支持代码块、表格、链接、加粗等 markdown 语法
    */
-  private async sendMarkdownMessage(userId: string, text: string): Promise<boolean> {
+  private async sendMarkdownCardMessage(userId: string, text: string): Promise<boolean> {
     try {
       const receiveIdType = this.config.receiveIdType || "open_id";
+      const card = buildMarkdownCard(text);
 
       const responseBody = {
         receive_id: userId,
-        msg_type: "post",
-        content: JSON.stringify({
-          zh_cn: {
-            content: [[{ tag: "md", text }]]
-          }
-        })
+        msg_type: "interactive",
+        content: JSON.stringify(card),
       };
 
-      const response = await fetch(`https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`, {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${this.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(responseBody),
-      });
+      const response = await fetch(
+        `https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(responseBody),
+        }
+      );
 
       const result = await response.json();
       if (result.code === 0) {
-        console.log(`[FeishuChannel] ✓ Sent: ${text.substring(0, 30)}${text.length > 30 ? "..." : ""}`);
+        console.log(
+          `[FeishuChannel] ✓ Sent card: ${text.substring(0, 30)}${text.length > 30 ? "..." : ""}`
+        );
         await sleep(1000);
         return true;
       } else {
-        console.error("[FeishuChannel] ✗ Send failed:", result.msg);
+        console.error("[FeishuChannel] ✗ Send card failed:", result.msg);
         return false;
       }
     } catch (error) {
-      console.error("[FeishuChannel] ✗ Send error:", error);
+      console.error("[FeishuChannel] ✗ Send card error:", error);
       return false;
     }
   }
@@ -888,6 +888,24 @@ export class FeishuChannel implements MessageChannel {
     } catch (error) {
       // 静默失败 - 清理不是关键功能
     }
+  }
+
+  /**
+   * 创建飞书流式卡片会话
+   * 用于 AI 回复实时更新到单个卡片，替代逐条发送消息
+   */
+  createStreamingSession(): FeishuStreamingSession {
+    return new FeishuStreamingSession(
+      { appId: this.config.appId, appSecret: this.config.appSecret },
+      (msg) => console.log(msg)
+    );
+  }
+
+  /**
+   * 暴露配置（供流式会话使用）
+   */
+  getConfig(): FeishuChannelConfig {
+    return this.config;
   }
 
   /**

--- a/.claude/skills/mycc/scripts/src/http-server.ts
+++ b/.claude/skills/mycc/scripts/src/http-server.ts
@@ -255,6 +255,13 @@ export class HttpServer {
   }
 
   private async handleChat(req: http.IncomingMessage, res: http.ServerResponse) {
+    // 渠道开关检查
+    if (process.env.CHANNEL_WEB === "false") {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Web channel is disabled" }));
+      return;
+    }
+
     // 验证 token
     const authHeader = req.headers.authorization;
     const token = authHeader?.replace("Bearer ", "");
@@ -710,12 +717,12 @@ export class HttpServer {
         console.log(`[${this.isTls ? "HTTPS" : "HTTP"}] 服务启动在端口 ${port}`);
 
         // 动态加载并注册飞书通道（如果配置了环境变量）
-        if (process.env.FEISHU_APP_ID && process.env.FEISHU_APP_SECRET) {
+        if (process.env.CHANNEL_FEISHU !== "false" && process.env.FEISHU_APP_ID && process.env.FEISHU_APP_SECRET) {
           try {
             const { FeishuChannel } = await import("./channels/feishu.js");
             this.feishuChannel = new FeishuChannel();
-            this.feishuChannel.onMessage(async (message: string, images?: Array<{ data: string; mediaType: string }>) => {
-              await this.feishuCommands.processMessage(message, images);
+            this.feishuChannel.onMessage(async (message: string, images?: Array<{ data: string; mediaType: string }>, messageId?: string) => {
+              await this.feishuCommands.processMessage(message, images, messageId);
             });
             this.channelManager.register(this.feishuChannel);
             // 注入 feishuChannel 到 FeishuCommands（延迟注入）

--- a/.claude/skills/mycc/scripts/src/index.ts
+++ b/.claude/skills/mycc/scripts/src/index.ts
@@ -107,11 +107,16 @@ async function startServer(args: string[]) {
   // 注意：此时可能还不知道项目根目录，所以搜索多个位置
   loadEnvFile(process.cwd(), scriptsDir);
 
+  // Web 渠道禁用时：跳过 tunnel，忽略 PUBLIC_URL
+  const webChannelDisabled = process.env.CHANNEL_WEB === "false";
+
   // 检测公网模式（读取 .env 中的 PUBLIC_URL）
-  const publicUrl = loadPublicUrl(process.cwd(), scriptsDir);
+  const publicUrl = webChannelDisabled ? null : loadPublicUrl(process.cwd(), scriptsDir);
   const isPublicMode = !!publicUrl;
 
-  if (isPublicMode) {
+  if (webChannelDisabled) {
+    console.log(chalk.yellow("\nWeb 渠道已禁用，跳过 tunnel\n"));
+  } else if (isPublicMode) {
     console.log(chalk.cyan(`\n公网模式: ${publicUrl}`));
     console.log(chalk.gray("  跳过 cloudflared（不需要内网穿透）\n"));
   } else {
@@ -293,7 +298,11 @@ ${skillLine}
   let tunnelUrl: string;
   let tunnelManager: TunnelManager | null = null;
 
-  if (isPublicMode) {
+  if (webChannelDisabled) {
+    // Web 渠道禁用：不启动 tunnel，忽略 PUBLIC_URL
+    tunnelUrl = "http://localhost disabled";
+    tunnelManager = null;
+  } else if (isPublicMode) {
     // 公网模式：直接用 PUBLIC_URL，不启动 tunnel
     tunnelUrl = publicUrl!;
     console.log(chalk.green(`✓ 使用公网地址: ${tunnelUrl}\n`));
@@ -345,9 +354,13 @@ ${skillLine}
   let mpUrl: string;
 
   if (tunnelManager === null && !isPublicMode) {
-    // Tunnel 不可用，跳过 Worker 注册
-    console.warn(chalk.yellow("Tunnel 不可用，跳过 Worker 注册"));
-    console.warn(chalk.yellow("Web 通道不可用，仅飞书通道可用\n"));
+    // Web 渠道禁用或 Tunnel 不可用，跳过 Worker 注册
+    if (webChannelDisabled) {
+      console.log(chalk.yellow("Web 渠道已禁用，跳过 Worker 注册，仅飞书通道可用\n"));
+    } else {
+      console.warn(chalk.yellow("Tunnel 不可用，跳过 Worker 注册"));
+      console.warn(chalk.yellow("Web 通道不可用，仅飞书通道可用\n"));
+    }
     mpUrl = "http://localhost disabled";
   } else {
     console.log(chalk.yellow("向中转服务器注册...\n"));

--- a/.claude/skills/mycc/scripts/tests/channel-feishu.test.ts
+++ b/.claude/skills/mycc/scripts/tests/channel-feishu.test.ts
@@ -176,7 +176,7 @@ describe("FeishuChannel", () => {
       const sendCall = mockFetch.mock.calls[1];
       expect(sendCall[0]).toContain("/im/v1/messages");
       const body = JSON.parse(sendCall[1].body);
-      expect(body.msg_type).toBe("post");
+      expect(body.msg_type).toBe("interactive");
       expect(body.receive_id).toBe("ou_test_user");
     });
 
@@ -419,7 +419,7 @@ describe("FeishuChannel", () => {
       expect(body.msg_type).toBe("interactive");
     });
 
-    it("纯文本消息发送 post 格式", async () => {
+    it("纯文本消息发送 interactive card 格式（schema 2.0）", async () => {
       await channel.send({ type: "text", text: "no table here" });
 
       const sendCalls = mockFetch.mock.calls.filter(
@@ -427,7 +427,9 @@ describe("FeishuChannel", () => {
       );
       expect(sendCalls).toHaveLength(1);
       const body = JSON.parse(sendCalls[0][1].body);
-      expect(body.msg_type).toBe("post");
+      expect(body.msg_type).toBe("interactive");
+      const card = JSON.parse(body.content);
+      expect(card.schema).toBe("2.0");
     });
   });
 
@@ -601,7 +603,7 @@ describe("FeishuChannel", () => {
       expect(sendCalls).toHaveLength(1);
 
       const body = JSON.parse(sendCalls[0][1].body);
-      expect(body.msg_type).toBe("post");
+      expect(body.msg_type).toBe("interactive");
     });
 
     it("sendMessageToFeishu - getAccessToken 返回 null → 返回 false", async () => {
@@ -745,8 +747,8 @@ describe("FeishuChannel", () => {
         session_id: "sess-1",
       });
 
-      // 验证顺序：先上传图片 → 发送图片消息 → 发送文字消息
-      expect(callOrder).toEqual(["upload_image", "send_image", "send_post"]);
+      // 验证顺序：先上传图片 → 发送图片消息 → 发送文字消息（现在文字走 interactive card）
+      expect(callOrder).toEqual(["upload_image", "send_image", "send_interactive"]);
     });
 
     it("system + images 上传失败 → 不崩", async () => {
@@ -804,7 +806,7 @@ describe("FeishuChannel", () => {
       });
     });
 
-    it("sendMarkdownMessage - 飞书 API 返回 code != 0 → 返回 false 不崩", async () => {
+    it("sendMarkdownCardMessage - 飞书 API 返回 code != 0 → 返回 false 不崩", async () => {
       mockFetch.mockImplementation((url: string) => {
         if (url.includes("tenant_access_token")) {
           return Promise.resolve({
@@ -826,7 +828,7 @@ describe("FeishuChannel", () => {
         });
       });
 
-      // 纯文本走 sendMarkdownMessage 路径
+      // 纯文本走 sendMarkdownCardMessage 路径
       await expect(
         channel.send({ type: "text", text: "rate limited message" })
       ).resolves.toBeUndefined();
@@ -837,10 +839,10 @@ describe("FeishuChannel", () => {
       );
       expect(sendCalls).toHaveLength(1);
       const body = JSON.parse(sendCalls[0][1].body);
-      expect(body.msg_type).toBe("post"); // 普通文本走 post
+      expect(body.msg_type).toBe("interactive"); // 现在所有文本都走 interactive card
     });
 
-    it("sendMarkdownMessage - fetch 抛异常（网络中断）→ 不向上抛", async () => {
+    it("sendMarkdownCardMessage - fetch 抛异常（网络中断）→ 不向上抛", async () => {
       mockFetch.mockImplementation((url: string) => {
         if (url.includes("tenant_access_token")) {
           return Promise.resolve({
@@ -1071,7 +1073,7 @@ describe("FeishuChannel", () => {
       expect((channel as any).currentReactionId).toBeNull();
     });
 
-    it("text 事件含 Markdown 表格 → 走 interactive card 路径", async () => {
+    it("text 事件含 Markdown 表格 → 走 schema 2.0 markdown 卡片路径", async () => {
       const tableText = [
         "以下是分析结果：",
         "",
@@ -1092,16 +1094,16 @@ describe("FeishuChannel", () => {
       const body = JSON.parse(sendCalls[0][1].body);
       expect(body.msg_type).toBe("interactive");
 
-      // 验证卡片内容包含表格数据
+      // 验证是 schema 2.0 markdown 卡片，表格内容保留在 markdown 中
       const card = JSON.parse(body.content);
-      // 卡片 elements 应包含表格元素
-      const tableElement = card.elements.find((e: any) => e.tag === "table");
-      expect(tableElement).toBeDefined();
-      expect(tableElement.columns).toHaveLength(3);
-      expect(tableElement.rows).toHaveLength(2);
+      expect(card.schema).toBe("2.0");
+      const markdownElement = card.body.elements.find((e: any) => e.tag === "markdown");
+      expect(markdownElement).toBeDefined();
+      expect(markdownElement.content).toContain("DAU");
+      expect(markdownElement.content).toContain("留存");
     });
 
-    it("parseMarkdownTable 表格前后有文字 → 正确分离", async () => {
+    it("parseMarkdownTable 表格前后有文字 → schema 2.0 卡片包含完整内容", async () => {
       const textWithTable = [
         "前置文字第一行",
         "前置文字第二行",
@@ -1123,25 +1125,15 @@ describe("FeishuChannel", () => {
       expect(body.msg_type).toBe("interactive");
 
       const card = JSON.parse(body.content);
-      // 应有：前置文字 div + table + 后置文字 div
-      const divElements = card.elements.filter((e: any) => e.tag === "div");
-      const tableElements = card.elements.filter((e: any) => e.tag === "table");
-
-      expect(tableElements).toHaveLength(1);
-      // 前置文字和后置文字应该在 div 元素中
-      expect(divElements.length).toBeGreaterThanOrEqual(1);
-
-      // 前置文字包含原文
-      const beforeDiv = divElements[0];
-      expect(beforeDiv.text.content).toContain("前置文字");
-
-      // 后置文字
-      if (divElements.length >= 2) {
-        expect(divElements[1].text.content).toContain("后置文字");
-      }
+      expect(card.schema).toBe("2.0");
+      const markdownElement = card.body.elements.find((e: any) => e.tag === "markdown");
+      expect(markdownElement).toBeDefined();
+      // 前置文字、表格内容、后置文字都在 markdown 中
+      expect(markdownElement.content).toContain("前置文字");
+      expect(markdownElement.content).toContain("后置文字");
     });
 
-    it("parseMarkdownTable 多列复杂表格 → 正确解析", async () => {
+    it("parseMarkdownTable 多列复杂表格 → schema 2.0 卡片保留表格内容", async () => {
       const complexTable = [
         "| 项目 | 负责人 | 状态 | 截止日期 | 备注 |",
         "|------|--------|------|----------|------|",
@@ -1160,19 +1152,13 @@ describe("FeishuChannel", () => {
       expect(body.msg_type).toBe("interactive");
 
       const card = JSON.parse(body.content);
-      const tableElement = card.elements.find((e: any) => e.tag === "table");
-      expect(tableElement).toBeDefined();
-
-      // 5 列
-      expect(tableElement.columns).toHaveLength(5);
-      expect(tableElement.columns[0].display_name).toBe("项目");
-      expect(tableElement.columns[4].display_name).toBe("备注");
-
-      // 3 行数据
-      expect(tableElement.rows).toHaveLength(3);
-      expect(tableElement.rows[0].col_0).toBe("登录");
-      expect(tableElement.rows[1].col_1).toBe("李四");
-      expect(tableElement.rows[2].col_2).toBe("待开始");
+      expect(card.schema).toBe("2.0");
+      const markdownElement = card.body.elements.find((e: any) => e.tag === "markdown");
+      expect(markdownElement).toBeDefined();
+      // 验证表格内容保留
+      expect(markdownElement.content).toContain("登录");
+      expect(markdownElement.content).toContain("李四");
+      expect(markdownElement.content).toContain("待开始");
     });
   });
 });

--- a/start-mycc.ps1
+++ b/start-mycc.ps1
@@ -6,7 +6,7 @@
 $OutputEncoding = [System.Text.Encoding]::UTF8
 
 # Configuration
-$PROJECT_DIR = "E:\AI\mycc\AImycc"
+$PROJECT_DIR = $PSScriptRoot
 $SCRIPT_DIR = "$PROJECT_DIR\.claude\skills\mycc\scripts"
 $LOG_FILE = "$PROJECT_DIR\.claude\skills\mycc\backend.log"
 $CONFIG_FILE = "$PROJECT_DIR\.claude\skills\mycc\current.json"
@@ -139,7 +139,9 @@ while ($elapsed -lt $timeout) {
     if (Test-Path $CONFIG_FILE) {
         try {
             $config = Get-Content $CONFIG_FILE -Raw | ConvertFrom-Json
-            if ($config.routeToken -and $config.pairCode -and $config.tunnelUrl) {
+            $webDisabled = ($env:CHANNEL_WEB -eq "false")
+            $readyCheck = if ($webDisabled) { $config.pairCode -and $config.tunnelUrl } else { $config.routeToken -and $config.pairCode -and $config.tunnelUrl }
+            if ($readyCheck) {
                 break
             }
         } catch {
@@ -187,19 +189,27 @@ Write-Host "+------------------------------------------+" -ForegroundColor White
 Write-Host ""
 
 Write-Host "+------------------------------------------+" -ForegroundColor White
-Write-Host "|  Feishu Channel Enabled:                  |" -ForegroundColor White
+Write-Host "|  Channel Status:                          |" -ForegroundColor White
 Write-Host "+------------------------------------------+" -ForegroundColor White
-Write-Host ("|  Feishu Group:   " + $env:FEISHU_RECEIVE_USER_ID) -ForegroundColor Cyan
-Write-Host "|  Status: ✓ Connected (WebSocket mode)    " -ForegroundColor Green
+$webStatus = if ($env:CHANNEL_WEB -eq "false") { "x Disabled" } else { "v Enabled" }
+$feishuStatus = if ($env:CHANNEL_FEISHU -eq "false") { "x Disabled" } elseif ($env:FEISHU_APP_ID) { "v Enabled (WebSocket)" } else { "x No credentials" }
+$webColor = if ($env:CHANNEL_WEB -eq "false") { "Gray" } else { "Green" }
+$feishuColor = if ($env:CHANNEL_FEISHU -eq "false") { "Gray" } elseif ($env:FEISHU_APP_ID) { "Green" } else { "Yellow" }
+Write-Host ("|  Web:    " + $webStatus) -ForegroundColor $webColor
+Write-Host ("|  Feishu: " + $feishuStatus) -ForegroundColor $feishuColor
 Write-Host "+------------------------------------------+" -ForegroundColor White
 Write-Host ""
 
-# Open browser
-Write-Host "Opening browser..." -ForegroundColor Gray
-try {
-    Start-Process $config.mpUrl
-} catch {
-    Write-Host "  Failed to open browser" -ForegroundColor Yellow
+# Open browser (only when Web channel is enabled)
+if ($env:CHANNEL_WEB -ne "false" -and $config.mpUrl) {
+    Write-Host "Opening browser..." -ForegroundColor Gray
+    try {
+        Start-Process $config.mpUrl
+    } catch {
+        Write-Host "  Failed to open browser" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "Web channel disabled, skipping browser open." -ForegroundColor Gray
 }
 
 Write-Host ""

--- a/stop-mycc.ps1
+++ b/stop-mycc.ps1
@@ -1,7 +1,8 @@
 # MyCC Backend Stop Script
 
-$PROJECT_DIR = "E:\AI\mycc\AImycc"
-$PID_FILE = "$PROJECT_DIR\.claude\skills\mycc\backend.pid"
+$PROJECT_DIR = $PSScriptRoot
+$MYCC_DIR = "$PROJECT_DIR\.claude\skills\mycc"
+$CONFIG_FILE = "$MYCC_DIR\current.json"
 
 Write-Host ""
 Write-Host "============================================" -ForegroundColor Red
@@ -9,71 +10,85 @@ Write-Host "       Stop MyCC Backend Service" -ForegroundColor Red
 Write-Host "============================================" -ForegroundColor Red
 Write-Host ""
 
-# Try to read PID from file first
-$pidFromFile = $null
-if (Test-Path $PID_FILE) {
-    $pidFromFile = Get-Content $PID_FILE -Raw -ErrorAction SilentlyContinue
-    if ($pidFromFile) {
-        $pidFromFile = $pidFromFile.Trim()
-    }
-}
+$killedAny = $false
 
-# Function to stop process by PID
-function Stop-BackendProcess {
-    param($processId, $source)
-    try {
-        $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-        if ($process) {
-            Write-Host "  Found process: $processId ($($process.ProcessName)) from $source" -ForegroundColor Cyan
-            Write-Host "  Stopping..." -ForegroundColor Yellow
-            Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds 1
+# 1. Kill process on port 18080 (node/tsx backend)
+Write-Host "[1/3] Stopping backend (port 18080)..." -ForegroundColor Yellow
+$portPids = Get-NetTCPConnection -LocalPort 18080 -ErrorAction SilentlyContinue |
+            Where-Object State -eq "Listen" |
+            Select-Object -ExpandProperty OwningProcess -ErrorAction SilentlyContinue
 
-            # Check if still running
-            $stillRunning = Get-Process -Id $processId -ErrorAction SilentlyContinue
-            if (-not $stillRunning) {
-                Write-Host "  Service stopped successfully" -ForegroundColor Green
-
-                # Remove PID file
-                if (Test-Path $PID_FILE) {
-                    Remove-Item $PID_FILE -Force -ErrorAction SilentlyContinue
-                }
-                return $true
-            } else {
-                Write-Host "  Failed to stop. Run: taskkill /F /PID $processId" -ForegroundColor Red
-                return $false
-            }
+if ($portPids) {
+    foreach ($procId in @($portPids)) {
+        $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
+        if ($proc) {
+            Write-Host "  Killing PID $procId ($($proc.ProcessName))" -ForegroundColor Cyan
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+            $killedAny = $true
         }
-    } catch {
-        return $false
     }
-    return $false
+} else {
+    Write-Host "  Port 18080 already free" -ForegroundColor Green
 }
 
-# 1. Try PID from file
-$stopped = $false
-if ($pidFromFile) {
-    Write-Host "[1/2] Checking saved PID..." -ForegroundColor Yellow
-    $stopped = Stop-BackendProcess -pid $pidFromFile -source "PID file"
+# 2. Kill cloudflared tunnel processes
+Write-Host "[2/3] Stopping cloudflared tunnel..." -ForegroundColor Yellow
+$cloudflaredProcs = Get-Process -Name "cloudflared" -ErrorAction SilentlyContinue
+if ($cloudflaredProcs) {
+    foreach ($proc in $cloudflaredProcs) {
+        Write-Host "  Killing cloudflared PID $($proc.Id)" -ForegroundColor Cyan
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        $killedAny = $true
+    }
+} else {
+    Write-Host "  No cloudflared process found" -ForegroundColor Green
 }
 
-# 2. Fallback to port check
-if (-not $stopped) {
-    Write-Host "[2/2] Checking port 18080..." -ForegroundColor Yellow
-    $portProcess = Get-NetTCPConnection -LocalPort 18080 -ErrorAction SilentlyContinue |
-                   Where-Object State -eq "Listen" |
-                   Select-Object -ExpandProperty OwningProcess -ErrorAction SilentlyContinue
+# 3. Clean up temp files and config
+Write-Host "[3/3] Cleaning up..." -ForegroundColor Yellow
+$filesToRemove = @(
+    "$MYCC_DIR\start_hidden_temp.vbs",
+    "$MYCC_DIR\start_backend_temp.bat",
+    "$MYCC_DIR\backend.pid",
+    $CONFIG_FILE
+)
+foreach ($f in $filesToRemove) {
+    if (Test-Path $f) {
+        Remove-Item $f -Force -ErrorAction SilentlyContinue
+        Write-Host "  Removed: $(Split-Path $f -Leaf)" -ForegroundColor Gray
+    }
+}
 
-    if ($portProcess) {
-        $stopped = Stop-BackendProcess -pid $portProcess -source "port 18080"
+Start-Sleep -Seconds 1
+
+# Verify port is free
+$stillListening = Get-NetTCPConnection -LocalPort 18080 -ErrorAction SilentlyContinue |
+                  Where-Object State -eq "Listen"
+if ($stillListening) {
+    Write-Host "  Port still in use, trying taskkill fallback..." -ForegroundColor Yellow
+    $netstatOutput = netstat -ano | findstr ":18080"
+    $pidsToKill = $netstatOutput | ForEach-Object {
+        if ($_ -match '\s+(\d+)$') { $matches[1] }
+    } | Sort-Object -Unique
+    foreach ($procId in $pidsToKill) {
+        Write-Host "  taskkill /PID $procId /F" -ForegroundColor Cyan
+        taskkill /PID $procId /F 2>&1 | Out-Null
+    }
+    Start-Sleep -Seconds 1
+    $stillListening2 = Get-NetTCPConnection -LocalPort 18080 -ErrorAction SilentlyContinue |
+                       Where-Object State -eq "Listen"
+    if ($stillListening2) {
+        Write-Host ""
+        Write-Host "  ERROR: Port 18080 still occupied, please check manually" -ForegroundColor Red
     } else {
-        Write-Host "  Port 18080 is free, service not running" -ForegroundColor Green
-        $stopped = $true
+        Write-Host ""
+        Write-Host "  All stopped OK (via taskkill)" -ForegroundColor Green
     }
+} else {
+    Write-Host ""
+    Write-Host "  All stopped OK" -ForegroundColor Green
 }
 
 Write-Host ""
 Write-Host "============================================" -ForegroundColor Red
 Write-Host ""
-
-Start-Sleep -Seconds 2


### PR DESCRIPTION
- 新增 feishu-streaming.ts：FeishuStreamingSession 实现实时流式卡片更新
- feishu-commands.ts：processMessage 支持 messageId，集成流式回复
- feishu.ts：透传 messageId，支持流式会话生命周期管理
- start/stop-mycc.ps1：$PROJECT_DIR 改用 $PSScriptRoot，支持 CHANNEL_WEB=false 禁用 Web 通道
- SKILL.md：更新启动说明，按通道开关条件展示连接信息
- package-lock.json：v0.5.2，claude-agent-sdk 升级至 ^0.2.63