### PR TITLE
feat: support gateway-backed GPT models

### DIFF
--- a/.claude/skills/mycc/scripts/scripts/patch-sdk.mjs
+++ b/.claude/skills/mycc/scripts/scripts/patch-sdk.mjs
@@ -26,19 +26,24 @@ const SDK_PATH = join(SDK_DIR, "sdk.mjs");
 // ============ Patch 1: sdk.mjs — settingSources ============
 
 const SETTINGS_ORIGINAL = "settingSources:[]";
-const SETTINGS_PATCHED = 'settingSources:X.settingSources??["user","project"]';
+const SETTINGS_PREVIOUS = 'settingSources:X.settingSources??["user","project"]';
+const SETTINGS_PATCHED = 'settingSources:X.settingSources??["user","project","local"]';
 
 try {
   const source = readFileSync(SDK_PATH, "utf-8");
 
   if (source.includes(SETTINGS_PATCHED)) {
     console.log("[patch-sdk] sdk.mjs: settingSources already patched.");
-  } else if (!source.includes(SETTINGS_ORIGINAL)) {
-    console.warn("[patch-sdk] sdk.mjs: settingSources pattern not found (SDK may have fixed it).");
-  } else {
+  } else if (source.includes(SETTINGS_PREVIOUS)) {
+    const patched = source.replace(SETTINGS_PREVIOUS, SETTINGS_PATCHED);
+    writeFileSync(SDK_PATH, patched, "utf-8");
+    console.log("[patch-sdk] sdk.mjs: upgraded settingSources default to include local.");
+  } else if (source.includes(SETTINGS_ORIGINAL)) {
     const patched = source.replace(SETTINGS_ORIGINAL, SETTINGS_PATCHED);
     writeFileSync(SDK_PATH, patched, "utf-8");
-    console.log("[patch-sdk] sdk.mjs: patched settingSources:[] → settingSources:X.settingSources??[\"user\",\"project\"]");
+    console.log("[patch-sdk] sdk.mjs: patched settingSources:[] → settingSources:X.settingSources??[\"user\",\"project\",\"local\"]");
+  } else {
+    console.warn("[patch-sdk] sdk.mjs: settingSources pattern not found (SDK may have fixed it).");
   }
 } catch (err) {
   console.error("[patch-sdk] sdk.mjs patch failed:", err.message);

--- a/.claude/skills/mycc/scripts/src/adapters/interface.ts
+++ b/.claude/skills/mycc/scripts/src/adapters/interface.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ChatParams, ConversationSummary, ConversationHistory } from "../types.js";
-import type { SDKSession } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKSession, SettingSource } from "@anthropic-ai/claude-agent-sdk";
 
 /** SSE 事件 */
 export type SSEEvent = Record<string, unknown>;
@@ -17,6 +17,8 @@ export interface SessionParams {
   sessionId?: string;
   model?: string;
   cwd?: string;
+  settingSources?: SettingSource[];
+  appendSystemPrompt?: string;
 }
 
 /** Adapter 接口 */

--- a/.claude/skills/mycc/scripts/src/adapters/official.ts
+++ b/.claude/skills/mycc/scripts/src/adapters/official.ts
@@ -271,8 +271,18 @@ export class OfficialAdapter implements CCAdapter {
     const session = this.getOrCreateSession({ sessionId, model, cwd, settingSources, appendSystemPrompt });
     const isNewSession = !sessionId;
 
+    const effectiveMessage = appendSystemPrompt
+      ? `[系统补充说明]
+${appendSystemPrompt}
+[/系统补充说明]
+
+[用户消息]
+${message}
+[/用户消息]`
+      : message;
+
     // 构造消息内容（纯文本或图文混合）
-    const content = buildMessageContent(message, images);
+    const content = buildMessageContent(effectiveMessage, images);
 
     // 根据内容类型选择 send 格式
     if (typeof content === "string") {

--- a/.claude/skills/mycc/scripts/src/adapters/official.ts
+++ b/.claude/skills/mycc/scripts/src/adapters/official.ts
@@ -7,6 +7,7 @@ import {
   unstable_v2_resumeSession,
   type SDKSession,
   type SDKUserMessage,
+  type SettingSource,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { CCAdapter, SSEEvent, SessionParams } from "./interface.js";
 import type { ChatParams, ConversationSummary, ConversationHistory } from "../types.js";
@@ -31,6 +32,28 @@ const CLAUDE_CLI_PATH = ensurePatchedCli(_systemCliPath, _patchedPath);
 
 /** v2 SDKSessionOptions 必须提供 model，这是默认值 */
 const DEFAULT_MODEL = "sonnet";
+const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
+type ClaudeCodeSystemPrompt = {
+  type: "preset";
+  preset: "claude_code";
+  append?: string;
+};
+type ExtendedSDKSessionOptions = Parameters<typeof unstable_v2_createSession>[0] & {
+  settingSources?: SettingSource[];
+  systemPrompt?: string | ClaudeCodeSystemPrompt;
+};
+
+function resolveAppendSystemPrompt(explicitAppend?: string): string | undefined {
+  const envAppend = process.env.MYCC_APPEND_SYSTEM_PROMPT?.trim();
+  const envIdentity = process.env.MYCC_UPSTREAM_MODEL_LABEL?.trim();
+
+  if (explicitAppend?.trim()) return explicitAppend.trim();
+  if (envAppend) return envAppend;
+  if (envIdentity) {
+    return `当前实际底层模型为 ${envIdentity}（可能通过兼容网关接入）。当用户询问你是什么模型时，请如实说明这一点，不要只重复兼容层的 Claude 模型别名。`;
+  }
+  return undefined;
+}
 
 /** Session 超时时间：15 分钟无活动自动关闭 */
 const SESSION_TIMEOUT_MS = 15 * 60 * 1000;
@@ -47,7 +70,7 @@ const CLEANUP_INTERVAL_MS = 2 * 60 * 1000;
 /**
  * 构造 v2 SDKSessionOptions
  */
-function buildSessionOptions(model?: string) {
+function buildSessionOptions(model?: string, settingSources?: SettingSource[], appendSystemPrompt?: string) {
   // 清除 CLAUDECODE 环境变量，避免子进程被误判为嵌套会话 (#16)
   const cleanEnv = { ...process.env };
   delete cleanEnv.CLAUDECODE;
@@ -55,8 +78,11 @@ function buildSessionOptions(model?: string) {
   // root 用户不能用 --dangerously-skip-permissions（CLI 安全限制）
   const isRoot = process.getuid?.() === 0;
 
-  const options: Parameters<typeof unstable_v2_createSession>[0] = {
+  const resolvedAppendSystemPrompt = resolveAppendSystemPrompt(appendSystemPrompt);
+
+  const options: ExtendedSDKSessionOptions = {
     model: model || DEFAULT_MODEL,
+    settingSources: settingSources ?? DEFAULT_SETTING_SOURCES,
     pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
     permissionMode: "bypassPermissions",
     ...(!isRoot && { allowDangerouslySkipPermissions: true }),
@@ -69,6 +95,14 @@ function buildSessionOptions(model?: string) {
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
     },
   };
+
+  if (resolvedAppendSystemPrompt) {
+    options.systemPrompt = {
+      type: "preset",
+      preset: "claude_code",
+      append: resolvedAppendSystemPrompt,
+    };
+  }
 
   // 如果检测到需要用 node 执行（npm 全局安装），设置 executable
   if (CLAUDE_EXECUTABLE === "node") {
@@ -115,7 +149,7 @@ export class OfficialAdapter implements CCAdapter {
    * 由 chat() 在 stream 中拿到 sessionId 后调 registerSession 存入池
    */
   getOrCreateSession(params: SessionParams): SDKSession {
-    const { sessionId, model, cwd } = params;
+    const { sessionId, model, cwd, settingSources, appendSystemPrompt } = params;
 
     // 池中有 → 复用
     if (sessionId && this.sessions.has(sessionId)) {
@@ -123,7 +157,7 @@ export class OfficialAdapter implements CCAdapter {
       return this.sessions.get(sessionId)!;
     }
 
-    const options = buildSessionOptions(model);
+    const options = buildSessionOptions(model, settingSources, appendSystemPrompt);
 
     // v2 SDKSessionOptions 没有 cwd 字段，子进程通过 process.cwd() 继承工作目录
     // 必须在创建 session（spawn 子进程）前 chdir 到正确目录，否则 skills 等功能失效
@@ -231,10 +265,10 @@ export class OfficialAdapter implements CCAdapter {
    * 5. 总安全阀（30 分钟）→ 强制退出
    */
   async *chat(params: ChatParams): AsyncIterable<SSEEvent> {
-    const { message, sessionId, images, model, cwd } = params;
+    const { message, sessionId, images, model, cwd, settingSources, appendSystemPrompt } = params;
 
     // 获取或创建 session
-    const session = this.getOrCreateSession({ sessionId, model, cwd });
+    const session = this.getOrCreateSession({ sessionId, model, cwd, settingSources, appendSystemPrompt });
     const isNewSession = !sessionId;
 
     // 构造消息内容（纯文本或图文混合）

--- a/.claude/skills/mycc/scripts/src/agent-resolver.ts
+++ b/.claude/skills/mycc/scripts/src/agent-resolver.ts
@@ -1,0 +1,36 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { join, resolve } from "path";
+
+export interface AgentItem {
+  id: string;
+  path: string;
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function listAgents(agentsDir: string): AgentItem[] {
+  if (!agentsDir || !existsSync(agentsDir)) return [];
+
+  return readdirSync(agentsDir)
+    .map((entry) => ({ entry, fullPath: join(agentsDir, entry) }))
+    .filter(({ fullPath }) => isDirectory(fullPath))
+    .map(({ entry, fullPath }) => ({ id: entry, path: fullPath }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function resolveAgentDir(agentId: string, agentsDir: string): string | null {
+  if (!agentId || !agentsDir || !existsSync(agentsDir)) return null;
+
+  const exact = resolve(agentsDir, agentId);
+  if (isDirectory(exact)) return exact;
+
+  const normalized = agentId.trim().toLowerCase();
+  const match = listAgents(agentsDir).find((agent) => agent.id.toLowerCase() === normalized);
+  return match?.path ?? null;
+}

--- a/.claude/skills/mycc/scripts/src/http-server.ts
+++ b/.claude/skills/mycc/scripts/src/http-server.ts
@@ -20,6 +20,7 @@ import { loadConfig } from "./config.js";
 import { SessionStats } from "./session-stats.js";
 import { FeishuCommands } from "./channels/feishu-commands.js";
 import { resolveAgentDir, listAgents } from "./agent-resolver.js";
+import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
 
 const PORT = process.env.PORT || 18080;
 
@@ -296,7 +297,7 @@ export class HttpServer {
 
     // agentId 路由：解析为 Agent 目录
     let effectiveCwd = this.cwd;
-    let settingSources: string[] | undefined;
+    let settingSources: SettingSource[] | undefined;
     if (agentId) {
       if (!this.agentsDir) {
         res.writeHead(404, { "Content-Type": "application/json" });
@@ -354,7 +355,15 @@ export class HttpServer {
 
     try {
       // 使用 adapter 的 chat 方法（返回 AsyncIterable）
-      for await (const data of adapter.chat({ message: chatMessage, sessionId, cwd: effectiveCwd, images, model: model || undefined, settingSources })) {
+      for await (const data of adapter.chat({
+        message: chatMessage,
+        sessionId,
+        cwd: effectiveCwd,
+        images,
+        model: model || undefined,
+        settingSources: settingSources || (["user", "project", "local"] satisfies SettingSource[]),
+        appendSystemPrompt: process.env.MYCC_APPEND_SYSTEM_PROMPT || undefined,
+      })) {
         if (data && typeof data === "object" && "type" in data) {
           // 提取 session_id
           if (data.type === "system" && "session_id" in data) {

--- a/.claude/skills/mycc/scripts/src/types.ts
+++ b/.claude/skills/mycc/scripts/src/types.ts
@@ -28,6 +28,8 @@ export interface PairState {
 
 // ============ 对话与历史 ============
 
+import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
+
 /** 图片数据（简化版，完整定义在 image-utils.ts） */
 export interface ImageData {
   data: string; // base64 编码（不含 data:image/xxx;base64, 前缀）
@@ -41,6 +43,8 @@ export interface ChatParams {
   cwd: string;
   images?: ImageData[];
   model?: string;
+  settingSources?: SettingSource[];
+  appendSystemPrompt?: string;
 }
 
 

--- a/.claude/skills/mycc/scripts/tests/model-selection.test.ts
+++ b/.claude/skills/mycc/scripts/tests/model-selection.test.ts
@@ -18,6 +18,19 @@ describe("模型选择 - ChatParams 类型", () => {
     expect(params.model).toBe("claude-opus-4-6");
   });
 
+
+  it("ChatParams 支持 settingSources 和 appendSystemPrompt", async () => {
+    const params: import("../src/types.js").ChatParams = {
+      message: "test",
+      cwd: "/tmp",
+      settingSources: ["user", "project", "local"],
+      appendSystemPrompt: "请如实说明底层模型",
+    };
+
+    expect(params.settingSources).toEqual(["user", "project", "local"]);
+    expect(params.appendSystemPrompt).toBe("请如实说明底层模型");
+  });
+
   it("ChatParams.model 是可选字段", async () => {
     const params: import("../src/types.js").ChatParams = {
       message: "test",
@@ -86,6 +99,25 @@ describe("模型选择 - HTTP body 解析", () => {
     expect(sessionId).toBe("session1");
     expect(model).toBe("claude-opus-4-6");
     expect(images).toBeUndefined();
+  });
+
+  it("附加字段可以透传到 adapter.chat 参数", () => {
+    const parsedBody = {
+      message: "hello",
+      settingSources: ["user", "project", "local"],
+      appendSystemPrompt: "当前底层模型为 gpt-5.4",
+    };
+    const cwd = "/tmp";
+
+    const chatParams = {
+      message: parsedBody.message,
+      cwd,
+      settingSources: parsedBody.settingSources,
+      appendSystemPrompt: parsedBody.appendSystemPrompt,
+    };
+
+    expect(chatParams.settingSources).toEqual(["user", "project", "local"]);
+    expect(chatParams.appendSystemPrompt).toContain("gpt-5.4");
   });
 
   it("JSON body 不含 model 时解构为 undefined", () => {

--- a/.claude/skills/mycc/scripts/tests/v2-session.test.ts
+++ b/.claude/skills/mycc/scripts/tests/v2-session.test.ts
@@ -918,7 +918,7 @@ describe("settingSources patch — 修复 Skills 加载", () => {
     // patch 后不应再有硬编码的 settingSources:[]
     // 注意：e6 构造函数中也可能有 settingSources，但 V9→e6 的那个必须有默认值
     // 用更精确的模式匹配 V9 构造函数中的 settingSources
-    expect(sdkSource).toContain('settingSources:X.settingSources??["user","project"]');
+    expect(sdkSource).toContain('settingSources:X.settingSources??["user","project","local"]');
   });
 
   it("patch 脚本应存在于 scripts/patch-sdk.mjs", () => {
@@ -973,6 +973,12 @@ describe("official.ts 实现结构", () => {
 
   it("OfficialAdapter 类实现了 CCAdapter 接口", () => {
     expect(officialSource).toMatch(/class\s+OfficialAdapter\s+implements\s+CCAdapter/);
+  });
+
+  it("buildSessionOptions 应传递 settingSources 和 appendSystemPrompt", () => {
+    expect(officialSource).toMatch(/settingSources:\s*settingSources\s*\?\?\s*DEFAULT_SETTING_SOURCES/);
+    expect(officialSource).toMatch(/MYCC_APPEND_SYSTEM_PROMPT|MYCC_UPSTREAM_MODEL_LABEL/);
+    expect(officialSource).toMatch(/options\.systemPrompt\s*=\s*\{/);
   });
 
   it("不再使用 query() 的 cwd 参数", () => {

--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,31 @@ cd .claude/skills/mycc/scripts && npm install && cd -
 **Dependencies**:
 - [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/): `brew install cloudflare/cloudflare/cloudflared`
 
+
+### Experimental: Use GPT or other models via a compatible gateway
+
+> The recommended setup is still the official Claude Code client. If you have an **Anthropic-compatible gateway**, mycc sessions can now inherit project/local settings and route to GPT or other upstream models.
+
+Create `.claude/settings.json` or `.claude/settings.local.json` in the project root:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://your-gateway.example.com",
+    "ANTHROPIC_AUTH_TOKEN": "sk-...",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.4",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.4",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini",
+    "MYCC_APPEND_SYSTEM_PROMPT": "The actual upstream model is gpt-5.4 via a compatible gateway. If the user asks which model is running, answer truthfully."
+  }
+}
+```
+
+Notes:
+- mycc now loads `user`, `project`, and `local` setting sources for SDK sessions
+- `MYCC_APPEND_SYSTEM_PROMPT` is optional and helps fix model self-identification behind compatibility layers
+- If your gateway expects custom model IDs, map them with `ANTHROPIC_DEFAULT_*_MODEL`
+
 ## FAQ
 
 **Q: Hooks not working?**

--- a/README.md
+++ b/README.md
@@ -166,6 +166,31 @@ cd .claude/skills/mycc/scripts && npm install && cd -
 **依赖**：
 - [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)：`brew install cloudflare/cloudflare/cloudflared`
 
+
+### 实验性：通过兼容网关接入 GPT / 其他模型
+
+> 仍然推荐使用官方原版 Claude Code；如果你有 **Anthropic 兼容网关**，现在也可以通过项目级设置让 mycc 会话使用 GPT 等其他模型。
+
+在项目根目录新建 `.claude/settings.json` 或 `.claude/settings.local.json`：
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://your-gateway.example.com",
+    "ANTHROPIC_AUTH_TOKEN": "sk-...",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.4",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.4",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini",
+    "MYCC_APPEND_SYSTEM_PROMPT": "当前实际底层模型为 gpt-5.4（通过兼容网关接入）。当用户询问你是什么模型时，请如实说明。"
+  }
+}
+```
+
+说明：
+- mycc 后端现在会为 SDK 会话加载 `user` / `project` / `local` 三类设置源
+- `MYCC_APPEND_SYSTEM_PROMPT` 是可选项，用于修正通过兼容层接入时的“自报模型”
+- 如果网关只识别自定义模型名，也可以配合 `ANTHROPIC_DEFAULT_*_MODEL` 做模型映射
+
 ## 常见问题
 
 **Q: Hooks 没生效？**


### PR DESCRIPTION
## Summary
- load `user`, `project`, and `local` setting sources for SDK-backed mycc sessions
- allow gateway users to append an identity/system note via `MYCC_APPEND_SYSTEM_PROMPT`
- document Anthropic-compatible gateway setup for GPT-style upstream models

## Why
mycc already supports official Claude Code SDK sessions, but SDK-backed chat sessions were not inheriting `.claude/settings.local.json`, which made Anthropic-compatible gateway setups fail in practice. That also made it hard to correct model self-identification when a compatibility layer routes Claude aliases to GPT-family upstream models.

## Changes
- pass `settingSources` through the adapter into `unstable_v2_createSession` / `unstable_v2_resumeSession`
- default SDK session setting sources to `user`, `project`, and `local`
- let `MYCC_APPEND_SYSTEM_PROMPT` or `MYCC_UPSTREAM_MODEL_LABEL` append clarifying instructions to Claude Code's default system prompt
- update the SDK patch script so existing installs can upgrade from the previous `user,project` patch to `user,project,local`
- add regression tests and README examples for Anthropic-compatible gateways

## Validation
- `npx vitest run tests/model-selection.test.ts tests/v2-session.test.ts`
- `npx tsc --noEmit` still reports the pre-existing `src/http-server.ts` -> `./agent-resolver.js` missing module issue on this branch
